### PR TITLE
Add assertions (A-Assertions)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ test {
 }
 
 application {
-    mainClassName = "duke.Launcher"
+    mainClassName = "duke.gui.Launcher"
 }
 
 shadowJar {
@@ -59,6 +59,7 @@ checkstyle {
     toolVersion = '8.29'
 }
 
-run{
+run {
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -50,6 +50,7 @@ public class Parser {
             case MARK:
                 return new Mark(taskId);
             default:
+                assert false: commandType;
                 throw new DukeException("Invalid Command Type!");
             }
 
@@ -99,11 +100,19 @@ public class Parser {
             String dateTime = "";
 
             if (taskDetails.contains("/by")) {
-                description = taskDetails.split("/by", 2)[0];
-                date = taskDetails.split("/by", 2)[1].substring(1);
+                try {
+                    description = taskDetails.split("/by", 2)[0];
+                    date = taskDetails.split("/by", 2)[1].substring(1);
+                } catch (StringIndexOutOfBoundsException e) {
+                    throw new DukeException("Missing deadline date or description!");
+                }
             } else if (taskDetails.contains("/at")) {
-                description = taskDetails.split("/at", 2)[0];
-                dateTime = taskDetails.split("/at", 2)[1].substring(1);
+                try {
+                    description = taskDetails.split("/at", 2)[0];
+                    dateTime = taskDetails.split("/at", 2)[1].substring(1);
+                } catch (StringIndexOutOfBoundsException e) {
+                    throw new DukeException("Missing event date or description!");
+                }
             }
 
             switch (commandType) {
@@ -122,10 +131,12 @@ public class Parser {
             case EVENT:
                 return new AddEvent(description, dateTime);
             default:
+                assert false: commandType.toString();
                 throw new DukeException("Sumimasen! I don't recognize this command. Please try again!");
             }
         }
 
+        assert false;
         return new Command();
     }
 }

--- a/src/main/java/duke/Storage.java
+++ b/src/main/java/duke/Storage.java
@@ -105,6 +105,7 @@ public class Storage {
                     }
                     break;
                 default:
+                    assert false: taskInput;
                     throw new DukeException("No valid tasks found in file!");
                 }
             }


### PR DESCRIPTION
Currently, there is no way to test assumptions in Duke. 
- It is important that we are able to test obvious assumptions so as to minimize the occurrence of obvious bugs.
- The easiest way to solve the current issue is to **add assertions to switch default cases**. 
- Rationale is that switch default cases should not happen and thus, we should be wary when the program hits a default switch case.
