### PR TITLE
Add undo command for Duke

### DIFF
--- a/src/main/java/duke/TextUi.java
+++ b/src/main/java/duke/TextUi.java
@@ -96,4 +96,13 @@ public class TextUi {
     public String showEmptyMsg() {
         return "Empty Much!";
     }
+
+    /**
+     * Method that tells the user that an action has been undone
+     * @param action The command that has been undone
+     * @return Action undone string
+     */
+    public String showUndoMsg(String action) {
+        return action + " has been undone!";
+    }
 }

--- a/src/main/java/duke/commands/AddDeadline.java
+++ b/src/main/java/duke/commands/AddDeadline.java
@@ -44,4 +44,16 @@ public class AddDeadline extends Command {
             return e.getMessage();
         }
     }
+
+    /**
+     * Method that undoes an add deadline command
+     * @param taskList tasks that are stored in Duke
+     * @return message after an add deadline command has been undone
+     * @throws DukeException in the event that the action is unable to be written into
+     * storage file
+     */
+    @Override
+    public String undo(TaskList taskList) throws DukeException {
+        return taskList.deleteLastTask();
+    }
 }

--- a/src/main/java/duke/commands/AddEvent.java
+++ b/src/main/java/duke/commands/AddEvent.java
@@ -44,4 +44,16 @@ public class AddEvent extends Command {
             return e.getMessage();
         }
     }
+
+    /**
+     * Method that undoes an add event command
+     * @param taskList tasks that are stored in Duke
+     * @return message after an add event command has been undone
+     * @throws DukeException in the event that the action is unable to be written into
+     * storage file
+     */
+    @Override
+    public String undo(TaskList taskList) throws DukeException {
+        return taskList.deleteLastTask();
+    }
 }

--- a/src/main/java/duke/commands/AddToDo.java
+++ b/src/main/java/duke/commands/AddToDo.java
@@ -36,9 +36,21 @@ public class AddToDo extends Command {
                 throw new DukeException("Todo command is invalid!");
             }
             Task todo = new Todo(taskDetails);
-            return TaskList.addTask(todo);
+            return taskList.addTask(todo);
         } catch (DukeException e) {
             return e.getMessage();
         }
+    }
+
+    /**
+     * Method that undoes an add todo command
+     * @param taskList tasks that are stored in Duke
+     * @return message after an add todo command has been undone
+     * @throws DukeException in the event that the action is unable to be written into
+     * storage file
+     */
+    @Override
+    public String undo(TaskList taskList) throws DukeException {
+        return taskList.deleteLastTask();
     }
 }

--- a/src/main/java/duke/commands/Command.java
+++ b/src/main/java/duke/commands/Command.java
@@ -2,6 +2,8 @@ package duke.commands;
 
 import duke.Storage;
 import duke.TextUi;
+import duke.exceptions.DukeException;
+import duke.exceptions.UndoException;
 import tasks.TaskList;
 
 /**
@@ -15,7 +17,11 @@ public class Command {
      * @param storage a storage object that is able to read and write to storage file
      * @return an empty string
      */
-    public String execute(TaskList taskList, TextUi ui, Storage storage) {
+    public String execute(TaskList taskList, TextUi ui, Storage storage) throws UndoException, DukeException {
+        return "";
+    }
+
+    public String undo(TaskList taskList) throws DukeException {
         return "";
     }
 }

--- a/src/main/java/duke/commands/Delete.java
+++ b/src/main/java/duke/commands/Delete.java
@@ -3,6 +3,7 @@ package duke.commands;
 import duke.Storage;
 import duke.TextUi;
 import duke.exceptions.DukeException;
+import tasks.Task;
 import tasks.TaskList;
 
 /**
@@ -10,6 +11,7 @@ import tasks.TaskList;
  */
 public class Delete extends Command {
     private final Integer taskId;
+    private Task deletedTask;
 
     /**
      * Initialize a Delete Command
@@ -29,9 +31,22 @@ public class Delete extends Command {
     @Override
     public String execute(TaskList taskList, TextUi ui, Storage storage) {
         try {
+            deletedTask = taskList.getTasks().get(taskId - 1);
             return TaskList.deleteTask(taskId);
         } catch (DukeException e) {
             return e.getMessage();
         }
+    }
+
+    /**
+     * Method that undoes a delete command
+     * @param taskList tasks that are stored in Duke
+     * @return message after a delete command has been undone
+     * @throws DukeException in the event that the action is unable to be written into
+     * storage file
+     */
+    @Override
+    public String undo(TaskList taskList) throws DukeException {
+        return taskList.addTaskBack(taskId, deletedTask);
     }
 }

--- a/src/main/java/duke/commands/Find.java
+++ b/src/main/java/duke/commands/Find.java
@@ -2,6 +2,7 @@ package duke.commands;
 
 import duke.Storage;
 import duke.TextUi;
+import duke.exceptions.UndoException;
 import tasks.TaskList;
 
 /**
@@ -28,7 +29,12 @@ public class Find extends Command {
      */
     @Override
     public String execute(TaskList taskList, TextUi ui, Storage storage) {
-        return TaskList.findTask(query);
+        return taskList.findTask(query);
+    }
+
+    @Override
+    public String undo(TaskList taskList) throws UndoException {
+        throw new UndoException("NOTHING");
     }
 
 }

--- a/src/main/java/duke/commands/List.java
+++ b/src/main/java/duke/commands/List.java
@@ -2,6 +2,7 @@ package duke.commands;
 
 import duke.Storage;
 import duke.TextUi;
+import duke.exceptions.UndoException;
 import tasks.TaskList;
 
 /**
@@ -17,6 +18,11 @@ public class List extends Command {
      */
     @Override
     public String execute(TaskList taskList, TextUi ui, Storage storage) {
-        return TaskList.listTasks();
+        return taskList.listTasks();
+    }
+
+    @Override
+    public String undo(TaskList taskList) throws UndoException {
+        throw new UndoException("NOTHING");
     }
 }

--- a/src/main/java/duke/commands/Mark.java
+++ b/src/main/java/duke/commands/Mark.java
@@ -29,9 +29,25 @@ public class Mark extends Command {
     @Override
     public String execute(TaskList taskList, TextUi ui, Storage storage) {
         try {
-            return TaskList.markTask(taskId, true);
+            return taskList.markTask(taskId, true);
         } catch (DukeException e) {
             return e.getMessage();
         }
     }
+
+    /**
+     * Method that undoes a mark command
+     * @param taskList tasks stored in Duke
+     * @return message after a mark command has been undone
+     */
+    @Override
+    public String undo(TaskList taskList) {
+        try {
+            return taskList.markTask(taskId, false);
+        } catch (DukeException e) {
+            return e.getMessage();
+        }
+    }
+
 }
+

--- a/src/main/java/duke/commands/Undo.java
+++ b/src/main/java/duke/commands/Undo.java
@@ -1,0 +1,37 @@
+package duke.commands;
+
+import duke.Storage;
+import duke.TextUi;
+import duke.exceptions.DukeException;
+import duke.exceptions.UndoException;
+import tasks.TaskList;
+
+/**
+ * Represents a command that allows the user to undo the most recent command
+ */
+public class Undo extends Command {
+    private final Command previousCommand;
+
+    /**
+     * Instantiates an undo command
+     * @param previousCommand stored previous command that we need to undo
+     */
+    public Undo(Command previousCommand) {
+        this.previousCommand = previousCommand;
+    }
+    /**
+     * Method that executes a command to undo the most recent command the user has keyed in
+     * @param taskList a taskList containing all existing tasks
+     * @param ui a ui object
+     * @param storage a storage object that is able to read and write to storage file
+     * @return message after a task has been marked
+     */
+    @Override
+    public String execute(TaskList taskList, TextUi ui, Storage storage) throws DukeException {
+        if (previousCommand != null) {
+            return previousCommand.undo(taskList);
+        }
+        throw new UndoException("EMPTY_PREVIOUS");
+    }
+}
+

--- a/src/main/java/duke/commands/Unmark.java
+++ b/src/main/java/duke/commands/Unmark.java
@@ -29,9 +29,24 @@ public class Unmark extends Command {
     @Override
     public String execute(TaskList taskList, TextUi ui, Storage storage) {
         try {
-            return TaskList.markTask(taskId, false);
+            return taskList.markTask(taskId, false);
         } catch (DukeException e) {
             return e.getMessage();
         }
     }
+
+    /**
+     * Method that undoes an unmark command
+     * @param taskList tasks stored in duke
+     * @return message after an unmark command has been undone
+     */
+    @Override
+    public String undo(TaskList taskList) {
+        try {
+            return taskList.markTask(taskId, true);
+        } catch (DukeException e) {
+            return e.getMessage();
+        }
+    }
+
 }

--- a/src/main/java/duke/exceptions/UndoException.java
+++ b/src/main/java/duke/exceptions/UndoException.java
@@ -1,0 +1,31 @@
+package duke.exceptions;
+
+/**
+ * Represents an exception that is thrown when there are errors when processing
+ * the undo command
+ */
+public class UndoException extends DukeException {
+    private final String errorCode;
+    /**
+     * Instantiates an UndoException
+     */
+    public UndoException(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        String message = "";
+        switch (errorCode) {
+        case "NOTHING":
+            message = "Nothing to undo here!";
+            break;
+        case "EMPTY_PREVIOUS":
+            message = "No previous commands can be found!";
+            break;
+        default:
+            assert false : errorCode;
+        }
+        return message;
+    }
+}

--- a/src/main/java/tasks/TaskList.java
+++ b/src/main/java/tasks/TaskList.java
@@ -7,10 +7,10 @@ import duke.Storage;
 import duke.TextUi;
 import duke.exceptions.DukeException;
 import duke.exceptions.TaskException;
+import duke.exceptions.UndoException;
 
 
 public class TaskList {
-
     private static ArrayList<Task> tasks = new ArrayList<>();
     private static final TextUi ui = new TextUi();
 
@@ -35,6 +35,7 @@ public class TaskList {
      */
     public static String deleteTask(int taskId) throws DukeException {
         Task preview = tasks.get(taskId - 1);
+        // System.out.println(tasks.size());
         tasks.remove(taskId - 1);
         Storage.writeToDukeFile();
         return ui.showDeleteMsg(preview);
@@ -133,5 +134,44 @@ public class TaskList {
         return ui.showFindTaskMsg(listTasks(matchingTasks));
     }
 
+    /**
+     * Method that is used to get tasks stored in Duke
+     * @return an arraylist of tasks
+     */
+    public ArrayList<Task> getTasks() {
+        return tasks;
+    }
+
+    /**
+     * Method that is used to undo a delete command
+     * @param taskId id of the task
+     * @param removedTask the type of task that is removed
+     * @return a message stating the successful undo of a delete command
+     * @throws DukeException when there are problems writing to duke file
+     */
+    public static String addTaskBack(Integer taskId, Task removedTask) throws DukeException {
+        try {
+            tasks.add(taskId - 1, removedTask);
+            Storage.writeToDukeFile();
+            return ui.showUndoMsg("Delete");
+        } catch (IndexOutOfBoundsException e) {
+            throw new UndoException("EMPTY_PREVIOUS");
+        }
+    }
+
+    /**
+     * Method to undo an add command
+     * @return a message stating the successful undo of an add command
+     * @throws DukeException when there are problems writing to duke file
+     */
+    public String deleteLastTask() throws DukeException {
+        try {
+            tasks.remove(tasks.size() - 1);
+            Storage.writeToDukeFile();
+            return ui.showUndoMsg("Add");
+        } catch (IndexOutOfBoundsException e) {
+            throw new UndoException("EMPTY_PREVIOUS");
+        }
+    }
 
 }


### PR DESCRIPTION
An undo command does not exist in the current duke.

Such a command is needed as users may want to undo an action that they made by mistake.

Add an undo command to allow users to undo add, mark, unmark and delete commands.

As all commands have different ways of undoing, it is better to override an undo method in the Command class and make use of polymorphism to customize each undo function.